### PR TITLE
Fix example date typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -505,7 +505,7 @@ Favorite feature,Polls,11/16/12,90,35,186,153,19
         <tr>
           <td>Sign-up referrer</td>
           <td>Search</td>
-          <td>10/25/12</td>
+          <td>10/26/12</td>
           <td>10</td>
           <td>10</td>
           <td>0</td>
@@ -514,7 +514,7 @@ Favorite feature,Polls,11/16/12,90,35,186,153,19
         <tr>
           <td>Sign-up referrer</td>
           <td>Email</td>
-          <td>10/26/12</td>
+          <td>10/25/12</td>
           <td>5</td>
           <td>5</td>
           <td>5</td>


### PR DESCRIPTION
I believe this is what was originally intended. It's the only way I can reconcile the documentation (which talks of unique type/value tuples) with the example data.
